### PR TITLE
✨ feat: login screen & routing setup

### DIFF
--- a/lib/login.dart
+++ b/lib/login.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+    @override
+  _LoginScreenState createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  @override
+  Widget build(BuildContext context) {
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Image.asset(
+                'lib/assets/images/splash_image.png',
+                height: 190,
+                fit: BoxFit.cover,
+              ),
+
+              SizedBox(height: 35),
+
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushReplacementNamed('/signup');
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xFFBDAD91),
+                  minimumSize: Size(240, 40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                ),
+                child: Text(
+                  '가입하기 (신규 사용자)',
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+
+              SizedBox(height: 10),
+
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushReplacementNamed('/signin');
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.white,
+                  minimumSize: Size(240, 40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(5),
+                    side: BorderSide(color: Color(0xFFBDAD91), width: 1),
+                  ),
+                ),
+                child: Text(
+                  '로그인 (기존 사용자)',
+                  style: TextStyle(
+                    color: Color(0xFFBDAD91),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SignupScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('SIGN UP'),
+        automaticallyImplyLeading: false,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pushReplacementNamed(context, '/login');
+          },
+        ),
+      ),
+      body: Center(
+        child: Text('empty screen for SIGNUP', style: TextStyle(fontSize: 24)),
+      ),
+    );
+  }
+}
+
+class SigninScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('SIGN IN'),
+        automaticallyImplyLeading: false,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pushReplacementNamed(context, '/login');
+          },
+        ),
+      ),
+      body: Center(
+        child: Text('empty screen for SIGNIN', style: TextStyle(fontSize: 24)),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'login.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -16,8 +18,9 @@ class MyApp extends StatelessWidget {
 
       routes: {
         '/': (context) => SplashScreen(title: '도담도담'),
-        // '/home': (context) => HomeScreen(),
-        // '/detail': (context) => DetailScreen(),
+        '/login': (context) => LoginScreen(),
+        '/signup': (context) => SignupScreen(),
+        '/signin': (context) => SigninScreen(),
       },
 
       theme: ThemeData(
@@ -37,7 +40,7 @@ class SplashScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     Future.delayed(Duration(seconds: 3), () {
       if (context.mounted) {
-        Navigator.of(context).pushReplacementNamed('/home');
+        Navigator.of(context).pushReplacementNamed('/login');
       }
     });
 


### PR DESCRIPTION
- login screen(`/login`): choose between '가입하기(/signup)' and '로그인(/signin)'
- routing setup: `/signup`, `/signin`